### PR TITLE
Add App Store badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,20 +82,9 @@
       margin-top: 1.5rem;
     }
 
-    .download-button {
-      display: inline-block;
+    .app-store-badge {
+      width: 160px;
       margin-top: 2rem;
-      padding: 0.75rem 1.5rem;
-      background-color: #3E8E4D;
-      color: white;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: bold;
-      transition: background-color 0.3s;
-    }
-
-    .download-button:hover {
-      background-color: #2D6A39;
     }
 
     footer {
@@ -120,12 +109,7 @@
         background-color: #4A3D2C;
         color: #F2B66D;
       }
-      .download-button {
-        background-color: #5CA068;
-      }
-      .download-button:hover {
-        background-color: #3E8E4D;
-      }
+      .app-store-badge { content: url('https://tools.applemediaservices.com/api/badges/download-on-the-app-store/white/es-es?size=200x67'); }
       footer { color: #808080; }
     }
   </style>
@@ -141,7 +125,9 @@
     <h1>Kookin está cocinando</h1>
     <p>Estamos trabajando en una nueva experiencia para ayudarte a planificar y disfrutar de tus recetas favoritas. ¡Muy pronto estará disponible!</p>
     <div class="badge">En construcción</div>
-    <a href="#" class="download-button">Descargar la app</a>
+    <a href="https://apps.apple.com/us/app/kookin/id6748577096">
+      <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=200x67" alt="Descargar en el App Store" class="app-store-badge">
+    </a>
   </div>
 
   <footer>


### PR DESCRIPTION
## Summary
- add App Store download badge using official assets
- switch dark mode to white badge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f3a9a4464832b80caf708b6db718d