### PR TITLE
Replace brand name with Deliteo

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "L8YSUA92XX.com.jmpg93.kukin",
+        "appID": "L8YSUA92XX.com.jmpg93.deliteo",
         "paths": [ "/recipe/*" ]
       }
     ]

--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Kookin es tu app para planificar y disfrutar recetas personalizadas. Muy pronto disponible.">
-  <title>Kookin — Próximamente</title>
-  <meta property="og:title" content="Kookin — Planifica tus recetas favoritas">
-  <meta property="og:description" content="Estamos cocinando algo delicioso. Muy pronto Kookin estará disponible.">
-  <meta property="og:image" content="https://kookin.app/image.png">
-  <meta property="og:url" content="https://kookin.app">
+  <meta name="description" content="Deliteo es tu app para planificar y disfrutar recetas personalizadas. Muy pronto disponible.">
+  <title>Deliteo — Próximamente</title>
+  <meta property="og:title" content="Deliteo — Planifica tus recetas favoritas">
+  <meta property="og:description" content="Estamos cocinando algo delicioso. Muy pronto Deliteo estará disponible.">
+  <meta property="og:image" content="https://deliteo.com/image.png">
+  <meta property="og:url" content="https://deliteo.com">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Kookin — Planifica tus recetas favoritas">
-  <meta name="twitter:description" content="Estamos cocinando algo delicioso. Muy pronto Kookin estará disponible.">
-  <meta name="twitter:image" content="https://kookin.app/image.png">
+  <meta name="twitter:title" content="Deliteo — Planifica tus recetas favoritas">
+  <meta name="twitter:description" content="Estamos cocinando algo delicioso. Muy pronto Deliteo estará disponible.">
+  <meta name="twitter:image" content="https://deliteo.com/image.png">
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -24,17 +24,17 @@
   </nav>
 
   <div class="container">
-    <img class="logo" src="image.png" alt="Logo de Kookin">
-    <h1>Kookin está cocinando</h1>
+    <img class="logo" src="image.png" alt="Logo de Deliteo">
+    <h1>Deliteo está cocinando</h1>
     <p>Estamos trabajando en una nueva experiencia para ayudarte a planificar y disfrutar de tus recetas favoritas. ¡Muy pronto estará disponible!</p>
     <div class="badge">En construcción</div>
-    <a href="https://apps.apple.com/us/app/kookin/id6748577096">
+    <a href="https://apps.apple.com/us/app/deliteo/id6748577096">
       <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=200x67" alt="Descargar en la App Store" class="app-store-badge">
     </a>
   </div>
 
   <footer>
-    <p>&copy; 2025 Kookin</p>
+    <p>&copy; 2025 Deliteo</p>
   </footer>
 </body>
 </html>

--- a/privacidad.html
+++ b/privacidad.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Política de privacidad de la app Kookin.">
-  <title>Política de privacidad · Kookin</title>
+  <meta name="description" content="Política de privacidad de la app Deliteo.">
+  <title>Política de privacidad · Deliteo</title>
   <link rel="icon" type="image/png" href="favicon.png" />
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -18,10 +18,10 @@
     <h1>Política de privacidad</h1>
     <p><strong>Última actualización:</strong> 10 de julio de 2025</p>
 
-    <p>Esta Política de Privacidad describe cómo Kookin recopila, utiliza y protege la información personal que puedas proporcionar a través de nuestra aplicación.</p>
+    <p>Esta Política de Privacidad describe cómo Deliteo recopila, utiliza y protege la información personal que puedas proporcionar a través de nuestra aplicación.</p>
 
     <h2>1. Información que recopilamos</h2>
-    <p>Kookin no recopila información personal identificable como nombre, correo electrónico o ubicación. La aplicación almacena únicamente datos relacionados con tus preferencias de recetas, ingredientes y configuraciones, localmente en tu dispositivo.</p>
+    <p>Deliteo no recopila información personal identificable como nombre, correo electrónico o ubicación. La aplicación almacena únicamente datos relacionados con tus preferencias de recetas, ingredientes y configuraciones, localmente en tu dispositivo.</p>
 
     <h2>2. Uso de la información</h2>
     <p>Los datos recopilados se utilizan exclusivamente para ofrecer funcionalidades como:</p>
@@ -41,9 +41,9 @@
     <p>Nos reservamos el derecho de modificar esta Política de Privacidad en cualquier momento. Te notificaremos cualquier cambio importante mediante una actualización en esta sección.</p>
 
     <h2>6. Contacto</h2>
-    <p>Si tienes preguntas sobre esta política, puedes escribirnos a <a href="mailto:contacto@kookin.app">contacto@kookin.app</a>.</p>
+    <p>Si tienes preguntas sobre esta política, puedes escribirnos a <a href="mailto:contacto@deliteo.com">contacto@deliteo.com</a>.</p>
 
-    <p>Al utilizar Kookin, aceptas esta Política de Privacidad.</p>
+    <p>Al utilizar Deliteo, aceptas esta Política de Privacidad.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update website references to use **Deliteo** instead of Kookin
- update Apple app association file

## Testing
- `grep -iRn kookin` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_688a6c422104832b8b1d8412650fa18e